### PR TITLE
Добавить pilot policy repo-guard для трассировки требований

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,32 @@
+## Summary
+
+<!-- Briefly describe the change. -->
+
+## Change Contract
+
+<!-- Keep this block in the PR body so repo-guard can validate the change. -->
+
+```repo-guard-yaml
+change_type: feature
+scope:
+  - "**"
+budgets:
+  max_new_files: 6
+  max_new_docs: 1
+  max_net_added_lines: 800
+# Add requirement IDs such as FR-001 when this PR affects, implements,
+# or verifies them.
+anchors:
+  affects: []
+  implements: []
+  verifies: []
+must_touch: []
+must_not_touch: []
+expected_effects:
+  - Describe the expected behavior change
+```
+
+## Test Plan
+
+- [ ] `node scripts/validate-requirements.js`
+- [ ] `node scripts/validate-docs-headings.js`

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-19T21:14:55.450Z for PR creation at branch issue-16-ac25dbefdb07 for issue https://github.com/netkeep80/pjson/issues/16

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-19T21:14:55.450Z for PR creation at branch issue-16-ac25dbefdb07 for issue https://github.com/netkeep80/pjson/issues/16

--- a/README.md
+++ b/README.md
@@ -67,6 +67,27 @@ node scripts/validate-requirements.js
 
 Проверяет соответствие схеме, согласованность трассировки и ссылки на файлы.
 
+### Repo-guard policy
+
+В корне репозитория находится `repo-policy.json` — pilot-конфиг для
+[`repo-guard`](https://github.com/netkeep80/repo-guard). Он описывает:
+
+- anchor types `requirement_id`, `code_req_ref`, `doc_req_ref`;
+- правила `must_resolve` для ссылок `@req` и документных ссылок на требования;
+- правило evidence: изменения файлов требований должны сопровождаться
+  изменениями в коде, тестах, документации, примерах, скриптах или CI;
+- базовые file-level guardrails для временных файлов, build artifacts и
+  co-change правил.
+
+Проверка policy через локальную копию `repo-guard`:
+
+```bash
+node /path/to/repo-guard/src/repo-guard.mjs --repo-root .
+```
+
+Для PR подготовлен пример change contract в
+[`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md).
+
 ## Формат комментариев в исходном коде
 
 Исходные файлы ссылаются на ID требований с помощью тега `@req`:

--- a/repo-policy.json
+++ b/repo-policy.json
@@ -1,0 +1,226 @@
+{
+  "policy_format_version": "0.3.0",
+  "repository_kind": "library",
+  "enforcement": {
+    "mode": "blocking"
+  },
+  "paths": {
+    "forbidden": [
+      "*.bak",
+      "**/*.bak",
+      "*.log",
+      "**/*.log",
+      "*.tmp",
+      "**/*.tmp",
+      "build/**",
+      "cmake-build-*/**",
+      "dist/**",
+      "node_modules/**"
+    ],
+    "canonical_docs": [
+      "README.md",
+      "requirements/README.md",
+      "docs/architecture.md",
+      "docs/development-plan.md",
+      "docs/pmm_requirements.md"
+    ],
+    "governance_paths": [
+      "repo-policy.json",
+      ".github/PULL_REQUEST_TEMPLATE.md",
+      ".github/workflows/",
+      "requirements/README.md",
+      "requirements/schemas/",
+      "scripts/validate-requirements.js",
+      "scripts/validate-docs-headings.js"
+    ],
+    "operational_paths": [
+      ".claude/**",
+      ".gitkeep"
+    ]
+  },
+  "diff_rules": {
+    "max_new_docs": 2,
+    "max_new_files": 12,
+    "max_net_added_lines": 1200
+  },
+  "anchors": {
+    "types": {
+      "requirement_id": {
+        "sources": [
+          {
+            "kind": "json_field",
+            "glob": "requirements/business/*.json",
+            "field": "id"
+          },
+          {
+            "kind": "json_field",
+            "glob": "requirements/stakeholder/*.json",
+            "field": "id"
+          },
+          {
+            "kind": "json_field",
+            "glob": "requirements/functional/*.json",
+            "field": "id"
+          },
+          {
+            "kind": "json_field",
+            "glob": "requirements/nonfunctional/*.json",
+            "field": "id"
+          },
+          {
+            "kind": "json_field",
+            "glob": "requirements/constraints/*.json",
+            "field": "id"
+          },
+          {
+            "kind": "json_field",
+            "glob": "requirements/interface/*.json",
+            "field": "id"
+          }
+        ]
+      },
+      "code_req_ref": {
+        "sources": [
+          {
+            "kind": "regex",
+            "glob": "scripts/*.js",
+            "pattern": "(?:@req\\s+|,\\s*)((?:BR|SR|FR|NFR|CR|IR)-[0-9]{3})"
+          },
+          {
+            "kind": "regex",
+            "glob": "scripts/**/*.js",
+            "pattern": "(?:@req\\s+|,\\s*)((?:BR|SR|FR|NFR|CR|IR)-[0-9]{3})"
+          },
+          {
+            "kind": "regex",
+            "glob": "include/**/*.{h,hpp,hh}",
+            "pattern": "(?:@req\\s+|,\\s*)((?:BR|SR|FR|NFR|CR|IR)-[0-9]{3})"
+          },
+          {
+            "kind": "regex",
+            "glob": "src/**/*.{h,hpp,hh,c,cc,cpp,cxx}",
+            "pattern": "(?:@req\\s+|,\\s*)((?:BR|SR|FR|NFR|CR|IR)-[0-9]{3})"
+          },
+          {
+            "kind": "regex",
+            "glob": "tests/**/*.{h,hpp,hh,c,cc,cpp,cxx,js,mjs}",
+            "pattern": "(?:@req\\s+|,\\s*)((?:BR|SR|FR|NFR|CR|IR)-[0-9]{3})"
+          },
+          {
+            "kind": "regex",
+            "glob": "examples/**/*.{h,hpp,hh,c,cc,cpp,cxx,js,mjs}",
+            "pattern": "(?:@req\\s+|,\\s*)((?:BR|SR|FR|NFR|CR|IR)-[0-9]{3})"
+          }
+        ]
+      },
+      "doc_req_ref": {
+        "sources": [
+          {
+            "kind": "regex",
+            "glob": "*.md",
+            "pattern": "(?:^|[^A-Z0-9])((?:BR|SR|FR|NFR|CR|IR)-[0-9]{3})(?![0-9])"
+          },
+          {
+            "kind": "regex",
+            "glob": "docs/**/*.md",
+            "pattern": "(?:^|[^A-Z0-9])((?:BR|SR|FR|NFR|CR|IR)-[0-9]{3})(?![0-9])"
+          },
+          {
+            "kind": "regex",
+            "glob": "requirements/**/*.md",
+            "pattern": "(?:^|[^A-Z0-9])((?:BR|SR|FR|NFR|CR|IR)-[0-9]{3})(?![0-9])"
+          },
+          {
+            "kind": "regex",
+            "glob": ".github/**/*.md",
+            "pattern": "(?:^|[^A-Z0-9])((?:BR|SR|FR|NFR|CR|IR)-[0-9]{3})(?![0-9])"
+          }
+        ]
+      }
+    }
+  },
+  "trace_rules": [
+    {
+      "id": "code-req-refs-must-resolve",
+      "kind": "must_resolve",
+      "from_anchor_type": "code_req_ref",
+      "to_anchor_type": "requirement_id"
+    },
+    {
+      "id": "doc-req-refs-must-resolve",
+      "kind": "must_resolve",
+      "from_anchor_type": "doc_req_ref",
+      "to_anchor_type": "requirement_id"
+    },
+    {
+      "id": "changed-requirements-need-evidence",
+      "kind": "changed_files_require_evidence",
+      "if_changed": [
+        "requirements/business/*.json",
+        "requirements/stakeholder/*.json",
+        "requirements/functional/*.json",
+        "requirements/nonfunctional/*.json",
+        "requirements/constraints/*.json",
+        "requirements/interface/*.json"
+      ],
+      "must_touch_any": [
+        "include/**",
+        "src/**",
+        "tests/**",
+        "examples/**",
+        "docs/**",
+        "README.md",
+        "requirements/README.md",
+        "scripts/**",
+        ".github/workflows/**"
+      ]
+    },
+    {
+      "id": "declared-affected-anchors-need-evidence",
+      "kind": "declared_anchors_require_evidence",
+      "contract_field": "anchors.affects",
+      "must_touch_any": [
+        "include/**",
+        "src/**",
+        "tests/**",
+        "examples/**",
+        "docs/**",
+        "README.md",
+        "requirements/README.md",
+        "scripts/**"
+      ]
+    }
+  ],
+  "content_rules": [
+    {
+      "id": "no-todo-without-issue",
+      "glob": "**",
+      "mode": "added_lines",
+      "forbid_regex": [
+        "[T]ODO(?!\\(#\\d+\\))"
+      ]
+    }
+  ],
+  "cochange_rules": [
+    {
+      "if_changed": [
+        "include/**/*.h",
+        "include/**/*.hpp",
+        "src/**/*.{h,hpp,hh,c,cc,cpp,cxx}"
+      ],
+      "must_change_any": [
+        "tests/**"
+      ]
+    },
+    {
+      "if_changed": [
+        "scripts/validate-requirements.js",
+        "scripts/validate-docs-headings.js"
+      ],
+      "must_change_any": [
+        "experiments/**",
+        ".github/workflows/**"
+      ]
+    }
+  ]
+}

--- a/repo-policy.json
+++ b/repo-policy.json
@@ -83,11 +83,6 @@
         "sources": [
           {
             "kind": "regex",
-            "glob": "scripts/*.js",
-            "pattern": "(?:@req\\s+|,\\s*)((?:BR|SR|FR|NFR|CR|IR)-[0-9]{3})"
-          },
-          {
-            "kind": "regex",
             "glob": "scripts/**/*.js",
             "pattern": "(?:@req\\s+|,\\s*)((?:BR|SR|FR|NFR|CR|IR)-[0-9]{3})"
           },
@@ -210,16 +205,6 @@
       ],
       "must_change_any": [
         "tests/**"
-      ]
-    },
-    {
-      "if_changed": [
-        "scripts/validate-requirements.js",
-        "scripts/validate-docs-headings.js"
-      ],
-      "must_change_any": [
-        "experiments/**",
-        ".github/workflows/**"
       ]
     }
   ]


### PR DESCRIPTION
## Summary

Решает задачу netkeep80/pjson#16 — добавляет pilot `repo-guard` policy для requirements-aware контроля в `pjson`.

### Что добавлено

- `repo-policy.json` с anchor-aware конфигурацией:
  - `requirement_id` из JSON-файлов требований;
  - `code_req_ref` из `@req` ссылок в скриптах и будущих source/test/example файлах;
  - `doc_req_ref` из Markdown-документации и PR template.
- Trace rules:
  - `must_resolve` для code/doc ссылок на требования;
  - evidence rule для изменений `requirements/**/*.json`;
  - evidence rule для declared `anchors.affects` в change contracts.
- File-level guardrails:
  - запрет backup/log/tmp/build artifacts;
  - budgets для новых файлов, новых Markdown-документов и net added lines;
  - co-change правило для будущих public/source changes -> tests.
- `.github/PULL_REQUEST_TEMPLATE.md` с готовым `repo-guard-yaml` contract snippet.
- README-секция с кратким описанием policy и командой validation.

### Review feedback addressed

- Убрано слишком жёсткое co-change правило `scripts/validate-*.js -> experiments/** или .github/workflows/**`.
- Убран пересекающийся `scripts/*.js` extractor pattern; оставлен `scripts/**/*.js`, который в текущем `repo-guard`/`minimatch` покрывает и root-level scripts, и вложенные scripts без дублей anchors.

## Change Contract

```repo-guard-yaml
change_type: requirements-policy
scope:
  - repo-policy.json
  - .github/PULL_REQUEST_TEMPLATE.md
  - README.md
budgets:
  max_new_files: 2
  max_new_docs: 1
  max_net_added_lines: 350
anchors:
  affects:
    - FR-005
    - FR-006
  implements: []
  verifies: []
must_touch:
  - repo-policy.json
must_not_touch:
  - requirements/**/*.json
expected_effects:
  - pjson has a valid repo-guard policy for requirements-aware anchor extraction
  - PR authors have a ready change-contract snippet
```

## Test plan

- [x] Reproduced original pre-fix state: `node /tmp/repo-guard-policy-reference/src/repo-guard.mjs --repo-root .` failed because `repo-policy.json` was missing
- [x] Reproduced review concern: validator-only changed file triggered the removed script co-change rule before the latest commit
- [x] Reproduced review concern: overlapping `scripts/*.js` and `scripts/**/*.js` produced duplicate script anchors before the latest commit
- [x] `node /tmp/repo-guard-policy-reference/src/repo-guard.mjs --repo-root .`
- [x] `node /tmp/repo-guard-policy-reference/src/repo-guard.mjs --repo-root . check-diff --base upstream/main --head HEAD --format summary` — 14 passed, 0 failed
- [x] Validator-only co-change probe after fix returns `[]`
- [x] Script anchor extraction after fix returns `duplicateCount: 0`
- [x] PR template contract extraction + schema validation via `repo-guard` markdown extractor
- [x] `node scripts/validate-requirements.js`
- [x] `node scripts/validate-docs-headings.js`
- [x] `bash experiments/test-validation.sh` — 9/9
- [x] `bash experiments/test-docs-headings-validation.sh` — 7/7
- [x] `git diff --check`

Fixes netkeep80/pjson#16
